### PR TITLE
only open one window

### DIFF
--- a/journalctl-mode.el
+++ b/journalctl-mode.el
@@ -134,19 +134,24 @@
   (let ((param (or flags (read-string "parameter: " "-x  -n 1000" nil "-x "))))
     (setq journalctl-current-lines (string-to-number (shell-command-to-string (concat "journalctl " param "|  wc -l"))))
     (let* ((this-chunk (or chunk  0)) ;; if chunk is not explicit given, we assume this first (0) chunk
-	 (first-line (+ 1 (* this-chunk journalctl-chunk-size)))
-	 (last-line (if (<= (+ first-line journalctl-chunk-size) journalctl-current-lines)
-			(+ first-line journalctl-chunk-size)
-		      journalctl-current-lines)))
-    (with-current-buffer (get-buffer-create "*journalctl*")
-      (setq buffer-read-only nil)
-      (fundamental-mode)
-      (erase-buffer))
-    (shell-command  (concat "journalctl " param journalctl-current-filter " | sed -ne '"  (int-to-string first-line) "," (int-to-string last-line) "p'") "*journalctl*" "*journalctl-error*")
-  (switch-to-buffer "*journalctl*")
-  (setq buffer-read-only t)
-  (setq journalctl-current-params param)
-  (journalctl-mode))))
+	         (first-line (+ 1 (* this-chunk journalctl-chunk-size)))
+	         (last-line (if (<= (+ first-line journalctl-chunk-size)
+                              journalctl-current-lines)
+			                    (+ first-line journalctl-chunk-size)
+		                    journalctl-current-lines)))
+      (with-current-buffer (get-buffer-create "*journalctl*")
+        (setq buffer-read-only nil)
+        (fundamental-mode)
+        (erase-buffer))
+      (save-window-excurion
+       (shell-command (concat "journalctl " param journalctl-current-filter
+                              " | sed -ne '"  (int-to-string first-line) ","
+                              (int-to-string last-line) "p'")
+                      "*journalctl*" "*journalctl-error*"))
+      (switch-to-buffer "*journalctl*")
+      (setq buffer-read-only t)
+      (setq journalctl-current-params param)
+      (journalctl-mode))))
 
 
 ;;;;;; Moving and Chunks

--- a/journalctl-mode.el
+++ b/journalctl-mode.el
@@ -143,7 +143,7 @@
         (setq buffer-read-only nil)
         (fundamental-mode)
         (erase-buffer))
-      (save-window-excurion
+      (save-window-excursion
        (shell-command (concat "journalctl " param journalctl-current-filter
                               " | sed -ne '"  (int-to-string first-line) ","
                               (int-to-string last-line) "p'")


### PR DESCRIPTION
For me, the `journalctl` command opens two windows because `shell-command` opens one, then `switch-to-window` opens another. So I wrapped `shell-command` in `save-window-excursion`. Not the most elegant solution but it works. Another approach would be to use `profess-file`, but that would require rewriting the whole function. Hope you don't mind the reformatting.