### PR TITLE
ENHANCEMENT: Don't calculate disk-usage when package is loaded

### DIFF
--- a/journalctl-mode.el
+++ b/journalctl-mode.el
@@ -131,11 +131,12 @@
   ""
   "Keeps filters as grep that shall be applied to journalctl's output.")
 
-(defvar journalctl-disk-usage
-  (concat
-   "Disk-usage: "
-   (shell-command-to-string "journalctl --disk-usage | egrep -o '[0-9.]+G'"))
-  "Disk-usage of  journalctl.")
+(defun journalctl--disk-usage ()
+  "Disk-usage of journalctl."
+  (let ((cmd-out (shell-command-to-string "journalctl --disk-usage")))
+    (if (string-match "[0-9.]+G" cmd-out)
+        (match-string 0 cmd-out)
+      "0G")))
 
 ;; functions
 
@@ -463,7 +464,7 @@ If OPT is set, remove this option."
 ;;;###autoload
 (define-derived-mode journalctl-mode fundamental-mode "journalctl"
   "Major mode for viewing journalctl output"
-  (setq mode-line-process journalctl-disk-usage)
+  (setq mode-line-process (concat " (disk usage: " (journalctl--disk-usage) ")"))
   ;; code for syntax highlighting
   (setq font-lock-defaults '((journalctl-font-lock-keywords))))
 


### PR DESCRIPTION
Change `journalctl-disk-usage` from a var to a private function.
Before, the disk-usage is only calculated once when you load the
package. Now it's queried each time you enter journalctl-mode.

Don't use egrep to find the size. egrep could behave different
on different systems. E.g. Arch Linux prints a warning.