### PR TITLE
Do not redefine variables defined elsewhere

### DIFF
--- a/journalctl-mode.el
+++ b/journalctl-mode.el
@@ -648,8 +648,8 @@ Move to next chunk when top of frame is reached."
     map)
   "Keymap for journalctl mode.")
 
-(defvar mode-line-process nil "Process status in the mode line.")
-(defvar font-lock-defaults nil "Defaults for Font Lock mode specified by the major mode.")
+(defvar mode-line-process)
+(defvar font-lock-defaults)
 
 ;;;###autoload
 (defun journalctl ()


### PR DESCRIPTION
Calling `defvar` with a variable name and no other arguments is fine
for addressing lints or byte-compiler warnings, but additional
arguments cause load-history (and therefore, `M-x find-variable`) to
incorrectly report these variables as being defined in
journalctl-mode.el.