### PR TITLE
Add --priority to Constraint section in transient menu

### DIFF
--- a/journalctl-mode.el
+++ b/journalctl-mode.el
@@ -418,6 +418,7 @@ It controls the formatting of the journal entries that are shown.")
     (journalctl-transient:--unit)
     (journalctl-transient:--user-unit)
     (journalctl-transient:--facility)
+    (journalctl-transient:--priority)
     ]
    ["Filters"
     (journalctl-transient:--since)


### PR DESCRIPTION
Include (journalctl-transient:--priority) in the Constraint section so the priority option appears in the transient menu.